### PR TITLE
fix(release): Distribute library as AAR file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,7 @@ buildscript {
 
 plugins {
     id("org.jetbrains.kotlin.jvm") version "$kotlinVersion"
-    id('java-library')
     id("org.jetbrains.dokka") version "1.4.20"
-    id('maven-publish')
     id("com.diffplug.spotless") version "5.11.0"
     id('idea')
 }
@@ -41,51 +39,6 @@ dokkaHtml.configure {
         configureEach {
             reportUndocumented.set(true)
             includes.from("api-docs.md")
-        }
-    }
-}
-
-publishing {
-    publications {
-        create("default", MavenPublication) {
-            from(components["java"])
-
-            pom {
-                name.set(rootProject.name)
-                description.set("High-level library for Android apps implementing Relaynet endpoints")
-                url.set("https://github.com/relaycorp/relaynet-endpoint-android")
-                developers {
-                    developer {
-                        id.set("relaycorp")
-                        name.set("Relaycorp, Inc.")
-                        email.set("no-reply@relaycorp.tech")
-                    }
-                }
-                licenses {
-                    license {
-                        name.set("Apache-2.0")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:https://github.com/relaycorp/relaynet-endpoint-android.git")
-                    developerConnection.set(
-                            "scm:git:https://github.com/relaycorp/relaynet-endpoint-android.git"
-                    )
-                    url.set("https://github.com/relaycorp/relaynet-endpoint-android")
-                }
-            }
-        }
-    }
-    repositories {
-        maven {
-            // publish=1 automatically publishes the version
-            url = uri(
-                    "https://api.bintray.com/maven/relaycorp/maven/tech.relaycorp.relaydroid/;publish=1"
-            )
-            credentials {
-                username = System.getenv("BINTRAY_USERNAME")
-                password = System.getenv("BINTRAY_KEY")
-            }
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,7 +1,8 @@
 plugins {
-  id 'com.android.library'
+  id 'com.android.library' // TODO: This is now in the root. Should we remove it here?
   id 'kotlin-android'
   id 'kotlin-kapt'
+  id 'maven-publish'
 }
 
 apply from: 'jacoco.gradle'
@@ -39,7 +40,7 @@ android {
     freeCompilerArgs += "-Xexplicit-api=strict"
   }
   testOptions {
-    unitTests{
+    unitTests {
       returnDefaultValues = true
       includeAndroidResources = true
     }
@@ -97,5 +98,55 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
       '-Xuse-experimental=kotlin.time.ExperimentalTime',
       '-Xuse-experimental=io.ktor.util.KtorExperimentalAPI'
     ]
+  }
+}
+
+afterEvaluate {
+  publishing {
+    publications {
+      release(MavenPublication) {
+        from components.release
+
+        groupId = 'tech.relaycorp'
+        artifactId = 'relaydroid'
+
+        pom {
+          name.set(rootProject.name)
+          description.set("High-level library for Android apps implementing Relaynet endpoints")
+          url.set("https://github.com/relaycorp/relaynet-endpoint-android")
+          developers {
+            developer {
+              id.set("relaycorp")
+              name.set("Relaycorp, Inc.")
+              email.set("no-reply@relaycorp.tech")
+            }
+          }
+          licenses {
+            license {
+              name.set("Apache-2.0")
+            }
+          }
+          scm {
+            connection.set("scm:git:https://github.com/relaycorp/relaynet-endpoint-android.git")
+            developerConnection.set(
+              "scm:git:https://github.com/relaycorp/relaynet-endpoint-android.git"
+            )
+            url.set("https://github.com/relaycorp/relaynet-endpoint-android")
+          }
+        }
+      }
+    }
+    repositories {
+      maven {
+        // publish=1 automatically publishes the version
+        url = uri(
+          "https://api.bintray.com/maven/relaycorp/maven/tech.relaycorp.relaydroid/;publish=1"
+        )
+        credentials {
+          username = System.getenv("BINTRAY_USERNAME")
+          password = System.getenv("BINTRAY_KEY")
+        }
+      }
+    }
   }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.android.library' // TODO: This is now in the root. Should we remove it here?
+  id 'com.android.library'
   id 'kotlin-android'
   id 'kotlin-kapt'
   id 'maven-publish'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,9 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}
 plugins {
     id("com.gradle.enterprise").version("3.3.4")
 }


### PR DESCRIPTION
Using: https://developer.android.com/studio/build/maven-publish-plugin

I had to upgrade Gradle because v6.6 was unsupported by this plugin.

Fixes #35