### PR TITLE
fix(ThirdPartyEndpoint): Demote certain public API members to internal

### DIFF
--- a/lib/src/test/java/tech/relaycorp/relaydroid/endpoint/PrivateThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/relaydroid/endpoint/PrivateThirdPartyEndpointTest.kt
@@ -41,7 +41,7 @@ internal class PrivateThirdPartyEndpointTest {
 
         with(PrivateThirdPartyEndpoint.load(firstAddress, thirdAddress)!!) {
             assertEquals(firstAddress, firstPartyAddress)
-            assertEquals(thirdAddress, address)
+            assertEquals(PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress, address)
             assertEquals(PDACertPath.PRIVATE_ENDPOINT, authorization)
             assertEquals(PDACertPath.PRIVATE_ENDPOINT, identityCertificate)
         }

--- a/lib/src/test/java/tech/relaycorp/relaydroid/endpoint/PublicThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/relaydroid/endpoint/PublicThirdPartyEndpointTest.kt
@@ -8,8 +8,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import tech.relaycorp.relaydroid.Relaynet
 import tech.relaycorp.relaydroid.storage.StorageImpl
 import tech.relaycorp.relaydroid.storage.mockStorage
@@ -37,7 +35,6 @@ internal class PublicThirdPartyEndpointTest {
             .thenReturn(PublicThirdPartyEndpoint.StoredData(publicAddress, PDACertPath.PUBLIC_GW))
 
         val endpoint = PublicThirdPartyEndpoint.load(privateAddress)!!
-        assertEquals(privateAddress, endpoint.thirdPartyAddress)
         assertEquals(publicAddress, endpoint.publicAddress)
         assertEquals("https://$publicAddress", endpoint.address)
         assertEquals(PDACertPath.PUBLIC_GW, endpoint.identityCertificate)
@@ -54,7 +51,6 @@ internal class PublicThirdPartyEndpointTest {
     fun import_successful() = runBlockingTest {
         val publicAddress = "example.org"
         with(PublicThirdPartyEndpoint.import(publicAddress, PDACertPath.PUBLIC_GW)) {
-            assertEquals(PDACertPath.PUBLIC_GW.subjectPrivateAddress, this.thirdPartyAddress)
             assertEquals(publicAddress, this.publicAddress)
             assertEquals(PDACertPath.PUBLIC_GW, identityCertificate)
             assertEquals("https://$publicAddress", this.address)

--- a/lib/src/test/java/tech/relaycorp/relaydroid/endpoint/ThirdPartyEndpointTest.kt
+++ b/lib/src/test/java/tech/relaycorp/relaydroid/endpoint/ThirdPartyEndpointTest.kt
@@ -1,0 +1,17 @@
+package tech.relaycorp.relaydroid.endpoint
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import tech.relaycorp.relaynet.testing.pki.PDACertPath
+
+internal class ThirdPartyEndpointTest {
+    @Test
+    fun privateAddress() {
+        val endpoint = PublicThirdPartyEndpoint(
+            "example.com",
+            PDACertPath.PRIVATE_ENDPOINT
+        )
+
+        assertEquals(PDACertPath.PRIVATE_ENDPOINT.subjectPrivateAddress, endpoint.privateAddress)
+    }
+}

--- a/lib/src/test/java/tech/relaycorp/relaydroid/test/ThirdPartyEndpointFactory.kt
+++ b/lib/src/test/java/tech/relaycorp/relaydroid/test/ThirdPartyEndpointFactory.kt
@@ -15,12 +15,10 @@ internal object ThirdPartyEndpointFactory {
 
     fun buildPublic(): PublicThirdPartyEndpoint = PublicThirdPartyEndpoint(
         "example.org",
-        UUID.randomUUID().toString(),
         PDACertPath.PUBLIC_GW
     )
 
     fun buildPrivate(): PrivateThirdPartyEndpoint = PrivateThirdPartyEndpoint(
-        UUID.randomUUID().toString(),
         UUID.randomUUID().toString(),
         PDACertPath.PRIVATE_ENDPOINT,
         PDACertPath.PRIVATE_ENDPOINT


### PR DESCRIPTION
Anything that app developers shouldn't be able to use.

Also consolidated naming for more consistency.
